### PR TITLE
Make AMF compliant with ACES 2

### DIFF
--- a/schema/acesMetadataFile.xsd
+++ b/schema/acesMetadataFile.xsd
@@ -64,12 +64,14 @@
 	<xs:simpleType name="tnLookTransform">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(LMT\.\S+\.\S+\.a\d+\.v\d+|LMT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
+			<xs:pattern value="urn:ampas:aces:transformId:v2.0:Look\.\S+\.\S+\.a\d+\.v\d+"/>
 		</xs:restriction>
 	</xs:simpleType>
 
 	<xs:simpleType name="tnInputTransform">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(IDT\.\S+\.\S+\.a\d+\.v\d+|ACEScsc\.\S+\.a\d+\.\d+\.\d+)"/>
+			<xs:pattern value="urn:ampas:aces:transformId:v2.0:(Input\.\S+\.\S+\.a\d+\.v\d+|CSC\.\S+\.a\d+\.v\d+)"/>
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -82,18 +84,21 @@
 	<xs:simpleType name="tnInverseOutputDeviceTransform">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(InvODT\.\S+\.\S+\.a\d+\.v\d+|InvODT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
+			<xs:pattern value="urn:ampas:aces:transformId:v2.0:InvOutput\.\S+\.\S+\.a\d+\.v\d+"/>
 		</xs:restriction>
 	</xs:simpleType>
 
 	<xs:simpleType name="tnOutputTransform">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(RRTODT\.\S+\.\S+\.a\d+\.v\d+|RRTODT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
+			<xs:pattern value="urn:ampas:aces:transformId:v2.0:Output\.\S+\.\S+\.a\d+\.v\d+"/>
 		</xs:restriction>
 	</xs:simpleType>
 	
 	<xs:simpleType name="tnInverseOutputTransform">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(InvRRTODT\.\S+\.\S+\.a\d+\.v\d+|InvRRTODT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
+			<xs:pattern value="urn:ampas:aces:transformId:v2.0:InvOutput\.\S+\.\S+\.a\d+\.v\d+"/>
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -112,6 +117,7 @@
 	<xs:simpleType name="tnColorSpaceConversionTransform">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(ACEScsc\.\S+\.\S+\.a\d+\.v\d+|ACEScsc\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
+			<xs:pattern value="urn:ampas:aces:transformId:v2.0:CSC\.\S+\.\S+\.a\d+\.v\d+"/>
 		</xs:restriction>
 	</xs:simpleType>
 	

--- a/schema/acesMetadataFile.xsd
+++ b/schema/acesMetadataFile.xsd
@@ -75,19 +75,6 @@
 		</xs:restriction>
 	</xs:simpleType>
 
-	<xs:simpleType name="tnOutputDeviceTransform">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(ODT\.\S+\.\S+\.a\d+\.v\d+|ODT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	
-	<xs:simpleType name="tnInverseOutputDeviceTransform">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(InvODT\.\S+\.\S+\.a\d+\.v\d+|InvODT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
-			<xs:pattern value="urn:ampas:aces:transformId:v2.0:InvOutput\.\S+\.\S+\.a\d+\.v\d+"/>
-		</xs:restriction>
-	</xs:simpleType>
-
 	<xs:simpleType name="tnOutputTransform">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(RRTODT\.\S+\.\S+\.a\d+\.v\d+|RRTODT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
@@ -101,7 +88,15 @@
 			<xs:pattern value="urn:ampas:aces:transformId:v2.0:InvOutput\.\S+\.\S+\.a\d+\.v\d+"/>
 		</xs:restriction>
 	</xs:simpleType>
-
+	
+	<xs:simpleType name="tnColorSpaceConversionTransform">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(ACEScsc\.\S+\.\S+\.a\d+\.v\d+|ACEScsc\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
+			<xs:pattern value="urn:ampas:aces:transformId:v2.0:CSC\.\S+\.\S+\.a\d+\.v\d+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	
+    <!-- ACES Version 1.x only -->
 	<xs:simpleType name="tnReferenceRenderingTransform">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:RRT\.a\d+\.\d+\.\d+"/>
@@ -113,13 +108,19 @@
 			<xs:pattern value="urn:ampas:aces:transformId:v1.5:InvRRT\.a\d+\.\d+\.\d+"/>
 		</xs:restriction>
 	</xs:simpleType>
-	
-	<xs:simpleType name="tnColorSpaceConversionTransform">
+
+	<xs:simpleType name="tnOutputDeviceTransform">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(ACEScsc\.\S+\.\S+\.a\d+\.v\d+|ACEScsc\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
-			<xs:pattern value="urn:ampas:aces:transformId:v2.0:CSC\.\S+\.\S+\.a\d+\.v\d+"/>
+			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(ODT\.\S+\.\S+\.a\d+\.v\d+|ODT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
 		</xs:restriction>
 	</xs:simpleType>
+	
+	<xs:simpleType name="tnInverseOutputDeviceTransform">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="urn:ampas:aces:transformId:v1.5:(InvODT\.\S+\.\S+\.a\d+\.v\d+|InvODT\.Academy\.\S+\.a\d+\.\d+\.\d+)"/>
+		</xs:restriction>
+	</xs:simpleType>
+    <!-- end ACES Version 1.x only -->
 	
 	<!-- Define clip identification types -->
 	<xs:complexType name="sequenceType">


### PR DESCRIPTION
The pattern in the transform type definitions needs to support transformId specification for ACES v2 transforms.

Strictly following the scheme, users _could_ mix and match older and newer transformID structures within an AMF, thus mixing incompatible v1 and v2 transforms. There is not way to apply logic to keep transformId pattern enforced based on the ACES version number declared in the AMF, without XSD 1.1. This limitation would need to be specified in the documentation since the XSD wouldn't be able to enforce it.