### PR TITLE
Added new example AMFs with official URNs for ACES 1.3 and 2.0

### DIFF
--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -21,6 +21,7 @@ jobs:
 
     - name: Validate XML Files
       run: |
-        for file in examples/*.amf; do
-          xmllint --noout --schema schema/acesMetadataFile.xsd $file
+        shopt -s globstar
+        for file in examples/**/*.amf; do
+          xmllint --noout --schema schema/acesMetadataFile.xsd "$file"
         done

--- a/examples/generated/aces1/idt_ACEScc_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScc_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScc to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.07Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.07Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:a866cda2-f4b7-4d4e-be07-e538f8404463</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.07Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.07Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:55147812-f5ef-4d53-9c18-779930dab767</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScc to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DCDM.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DCDM.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - DCDM</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.26Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.26Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:56774aa8-5022-4e34-a38c-0fbf99f7c83b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.26Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.26Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:517e1f8c-fb0d-4162-8429-bd80b85162b3</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - DCDM</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DCDM_P3D60.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DCDM_P3D60.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - DCDM (P3D60 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.25Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.25Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ef708521-e332-423e-9dbc-4b39b3c079fc</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.25Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.25Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:6200e702-7032-4bd6-91b5-71772b31fc23</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - DCDM (P3D60 Limited)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D60.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DCDM_P3D65limited.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DCDM_P3D65limited.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - DCDM (P3D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.26Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.26Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:8528b5f8-8c72-4279-b3e8-10ddc1e64e53</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.26Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.26Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:8f641b50-6eec-40bd-b5cd-2948a71d8ce6</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - DCDM (P3D65 Limited)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.DCDM_P3D65limited.a1.1.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DisplayP3_D60sim_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DisplayP3_D60sim_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - DisplayP3 (D60 sim.)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.26Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.26Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:cccb9b35-29fb-4351-979d-5029596494a5</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.26Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.26Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f5890f2d-532c-4f3e-988d-55637d253f8d</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - DisplayP3 (D60 sim.)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.DisplayP3_D60sim_dim.a1.0.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DisplayP3_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_DisplayP3_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - DisplayP3</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.27Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.27Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:35d419c0-2354-4e21-b1e9-dbcd9f3ef607</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.27Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.27Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:8e801fc8-4c40-4119-9e8f-69e1762f502f</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - DisplayP3</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.DisplayP3_dim.a1.0.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D60_48nits.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D60_48nits.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3-D60</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.27Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.27Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:16aae90d-e7c9-4e34-aeb0-1cdec91f6666</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.27Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.27Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:daca9477-8732-487a-a5c9-b3e8e272d8a2</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3-D60</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_1000nits_15nits_ST2084.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_1000nits_15nits_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3-D65 ST2084 (1000 nits)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.31Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.31Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:bd1e14e1-b706-4d8d-b01b-807a8f3f1d17</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.31Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.31Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:4ec35b25-3e0f-4ecb-8e40-9ca6fdcdf471</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3-D65 ST2084 (1000 nits)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_108nits_7point2nits_ST2084.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_108nits_7point2nits_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3D65 ST2084 (108 nits)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.32Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.32Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:cc05a5e2-30f3-4a20-93c8-8b2e10bb51ce</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.32Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.32Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:52a7b4a0-8c17-4037-b344-15a0a57cc86c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3D65 ST2084 (108 nits)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_2000nits_15nits_ST2084.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_2000nits_15nits_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3-D65 ST2084 (2000 nits)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.32Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.32Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:5614fbd9-2c62-4aa4-bbe3-347d2f9036c7</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.32Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.32Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:759a86e3-b736-4678-926c-00682c3f8f88</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3-D65 ST2084 (2000 nits)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_4000nits_15nits_ST2084.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_4000nits_15nits_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3-D65 ST2084 (4000 nits)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.32Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.32Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:2dbcbb52-677e-4e62-b94b-9b9c8b2ee55a</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.32Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.32Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:3ebd0641-fbeb-43e1-bcbb-32cbf2e08e93</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3-D65 ST2084 (4000 nits)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_48nits.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_48nits.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3D65</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.27Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.27Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:af5ef032-e30e-4aa9-9b48-94d13d38cd78</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.27Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.27Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:1baeac99-bb46-469f-80b4-842694aab788</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3D65</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_D60sim_48nits.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_D60sim_48nits.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3D65 (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.28Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.28Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:24737f25-1794-4550-a774-d2a5e78d9427</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.28Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.28Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:1f1dcf6e-895c-4382-bdf7-317a8dd39928</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3D65 (D60 simulation)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_Rec709limited_48nits.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3D65_Rec709limited_48nits.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3D65 (Rec.709 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.28Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.28Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:be28ba84-8930-4f99-bfe0-688accd18058</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.28Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.28Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:c21f5b5c-dc79-4b28-9195-c913e9fa5756</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3D65 (Rec.709 Limited)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_Rec709limited_48nits.a1.1.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3DCI_48nits.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3DCI_48nits.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3-DCI (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.28Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.28Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:758c90a8-fbb2-446b-96fd-e7d00bb4388b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.28Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.28Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:b188082e-66c2-44f6-8451-2984d9e7432c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3-DCI (D60 simulation)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3DCI_D65sim_48nits.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_P3DCI_D65sim_48nits.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - P3-DCI (D65 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.29Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.29Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:7a24bc11-7dbc-41c6-a1a3-1a4ac28d2a96</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.29Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.29Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:a92f3aed-9697-4cb5-afe5-14658aa41ee2</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - P3-DCI (D65 simulation)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_RGBmonitor_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_RGBmonitor_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - sRGB</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.31Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.31Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:3572ac9a-e1a9-40e8-8400-ba0874a366ff</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.31Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.31Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:036680ad-d8c9-471b-86c8-bacd3b3b9189</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - sRGB</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_RGBmonitor_D60sim_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_RGBmonitor_D60sim_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - sRGB (D60 sim.)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.31Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.31Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:5d2b3866-676b-4110-a60f-cd46af8679cb</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.31Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.31Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:e38e1149-2ae3-45b7-b19e-0015b61026b8</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - sRGB (D60 sim.)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_1000nits_15nits_HLG.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_1000nits_15nits_HLG.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.2020 HLG (1000 nits)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.33Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.33Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:bf046805-19a3-42c2-91ac-ee8cdb9e3364</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.33Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.33Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:61d4d008-8a2e-49ba-9d1b-effdb0199c00</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.2020 HLG (1000 nits)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_1000nits_15nits_ST2084.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_1000nits_15nits_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.2020 ST2084 (1000 nits)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.33Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.33Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:72041a81-77d0-4f4b-a45b-09741424c578</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.33Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.33Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:91f9260e-9d81-4840-979e-96dde610afea</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.2020 ST2084 (1000 nits)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.2020</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.29Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.29Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:8a287c9b-c97e-429f-ac1e-10792b88417f</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.29Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.29Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:899aab0b-4d08-48c5-a68a-e2bb48b226e8</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.2020</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_2000nits_15nits_ST2084.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_2000nits_15nits_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.2020 ST2084 (2000 nits)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.33Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.33Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:59ccbaf7-80a0-47d7-b1f6-671a1fe10cf4</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.33Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.33Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:1a03f4ad-12da-4029-89a7-ab3037398d45</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.2020 ST2084 (2000 nits)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_4000nits_15nits_ST2084.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_4000nits_15nits_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.2020 ST2084 (4000 nits)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.34Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.34Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:73a28d5e-9ab5-430a-a209-c518e93e809d</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.34Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.34Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:c10bd0b8-6c11-47dc-9973-3d5d19d62fb0</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.2020 ST2084 (4000 nits)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_P3D65limited_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_P3D65limited_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.2020 (P3D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.29Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.29Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:58265f93-d79e-4d30-ae4b-d1c73b8b0d61</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.29Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.29Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:82cf24b7-af2a-43a0-aadc-a5f3b7f0559a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.2020 (P3D65 Limited)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_P3D65limited_100nits_dim.a1.1.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_Rec709limited_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec2020_Rec709limited_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.2020 (Rec.709 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.30Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.30Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:0f323176-515a-46ad-8ab3-04c46b831bfa</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.30Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.30Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:dfa0df33-900a-44a8-87c6-7e44e902ec09</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.2020 (Rec.709 Limited)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits_dim.a1.1.0</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.30Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.30Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:2292761f-2c0e-453c-9214-91e35b50a8a1</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.30Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.30Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:4d0c3163-936a-4170-a11a-94da2093c5bd</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec709_D60sim_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScct_to_ACES__odt_Rec709_D60sim_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with ACES 1.0 Output - Rec.709 (D60 sim.)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.30Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.30Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:0dd536a4-419b-4df5-a78e-5e78ee6cce54</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.30Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.30Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:d9597aca-8b56-4e61-b7c4-91cfdad19f40</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709 (D60 sim.)</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACEScg_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACEScg_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScg to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.08Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.08Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:3e601f1b-4a9e-4fcc-becf-925b27750894</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.08Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.08Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:88d33cd5-1d25-4a9e-8fea-315c7f30a178</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScg to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACESproxy10i_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACESproxy10i_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACESproxy to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.08Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.08Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:a5d60edd-f2b2-47d7-92f5-32f89a6ea756</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.08Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.08Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:fa087fa3-6f9d-462a-bddc-cfdd8e5409f5</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACESproxy to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy10i_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ACESproxy12i_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ACESproxy12i_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACESproxy to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.09Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.09Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:c44ae3a7-ead1-4d2a-9638-fbdb0084ffe5</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.09Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.09Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:368e2b94-49ba-42cb-9eab-5864273b2439</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACESproxy to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACESproxy12i_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ADX10_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ADX10_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ADX10 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.09Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.09Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:51d9af7e-4214-45a1-bda5-e15cbdb9635a</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.09Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.09Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:21075d52-afd0-4d7c-a249-9cb62f1c3f6a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ADX10</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX10_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ADX16_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ADX16_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ADX16 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.09Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.09Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:a436cc1c-f1b9-4e90-b6a3-6f6abcd4c196</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.09Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.09Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f5b9ab66-c866-4bdd-b691-ef096c051e54</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ADX16</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX16_to_ACES.a1.0.3</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_ARRI_LogC4__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_ARRI_LogC4__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI LogC4 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.18Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.18Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ed69af12-0420-4234-b83c-1d71d7b69daf</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.18Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.18Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:af90a5be-bd37-4fff-a073-8ad9797f46f4</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI LogC4</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.ARRI-LogC4.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI1000__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI1000__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI1000) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.14Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.14Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:8d28b36a-43a2-4c40-bfd9-3ec771afd443</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.14Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.14Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:7e43e9c5-984e-41f2-a55b-b9db886d5b24</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI1000)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1000.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI1280__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI1280__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI1280) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.14Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.14Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:6abcb231-aad7-4c69-b999-3be3ee902262</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.14Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.14Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:9bd8f92f-9314-44c9-b3fa-9af3d82ee00a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI1280)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1280.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI1600__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI1600__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI1600) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.15Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.15Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:98da328b-6ca3-40b4-83ce-b274a3a19b60</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.15Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.15Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:fbaa52d2-c2c1-4774-bbb1-7ee4d1707119</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI1600)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI1600.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI160__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI160__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI160) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.14Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.14Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:1e5a8881-ccad-442c-a840-c23212a1b4ff</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.14Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.14Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:8ec0afa7-faa9-477d-8974-c2de4c1fb2b7</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI160)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI160.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI2000__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI2000__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI2000) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.15Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.15Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:dcc03b73-ae5b-4aa2-8880-e43e7a02474e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.15Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.15Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:4214d817-b274-437a-ae62-e32f474ccbe4</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI2000)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI2000.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI200__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI200__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI200) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.15Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.15Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:8013e9ec-05f4-42fb-be43-150e41444181</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.15Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.15Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:8640e46e-19ed-47f4-aff7-a2cf82eec7b7</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI200)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI200.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI250__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI250__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI250) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.16Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.16Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:3743feb4-836f-47cb-acc6-6b8cc7fea22e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.16Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.16Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:3b0dbf5f-6489-441e-af72-41c15b865a47</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI250)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI250.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI2560__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI2560__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI2560) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.16Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.16Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:6755bb70-891f-4bd1-b081-475281cd3292</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.16Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.16Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:fe8a2440-de7a-4a20-b6d1-3e035b0fecde</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI2560)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI2560.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI3200__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI3200__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI3200) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.17Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.17Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:1059f081-95fb-4101-811d-3271ae99830d</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.17Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.17Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:57b955a3-f040-4d38-b2e8-45d09c7869d3</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI3200)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI3200.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI320__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI320__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI320) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.16Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.16Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:3ad51ca7-59e2-4ceb-be68-7c9c0286e260</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.16Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.16Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:2a465efc-6131-4caa-a371-de913cdf1bb2</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI320)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI320.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI400__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI400__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI400) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.17Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.17Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:9a224a53-01fd-4680-afdd-5e69d7d28c2e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.17Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.17Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:85407ac0-2254-462d-91e3-9da66e1cef5a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI400)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI400.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI500__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI500__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI500) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.17Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.17Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:0f73abbb-c91d-4bf8-a89c-47fc5459363d</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.17Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.17Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f1521a22-bffd-49e7-ab67-348aa47a4c37</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI500)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI500.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI640__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI640__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI640) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.18Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.18Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:8dd5bfbc-02c2-4ee9-9d87-baee0348a199</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.18Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.18Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:22d97b81-0a6d-4a25-9ff1-b37500211bd4</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI640)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI640.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Alexa_v3_logC_EI800__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Alexa_v3_logC_EI800__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - ARRI V3 LogC (EI800) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.18Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.18Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:d23ec61f-a149-4a54-8203-85e4c797e066</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.18Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.18Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:df02d1cd-722b-4377-95e0-8275702ca00e</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - ARRI V3 LogC (EI800)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI800.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_AppleLog_BT2020__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_AppleLog_BT2020__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - AppleLog Rec2020 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.13Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.13Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:18fce6a1-ce01-434f-aa66-72cb555caa5d</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.13Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.13Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:a1cc538b-f77b-4f35-905c-8031c0f1fdb9</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - AppleLog Rec2020</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Apple.AppleLog_BT2020.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_BMDFilm_WideGamut_Gen5__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_BMDFilm_WideGamut_Gen5__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Blackmagic Film Wide Gamut (Gen 5) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.19Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.19Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:b2d25a9e-57be-41ef-81f7-233e84e7cfd0</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.19Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.19Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f7aa5a1c-8846-4a7a-a75e-6fd8768bc1de</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Blackmagic Film Wide Gamut (Gen 5)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.BlackmagicDesign.BMDFilm_WideGamut_Gen5.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CLog2_CGamut_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CLog2_CGamut_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Canon Log 2 Cinema Gamut to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.10Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.10Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:fa33ea14-956a-40f2-939f-f16cea24bed9</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.10Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.10Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:03ad77bf-a3ad-4101-9102-3168388f42d6</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Canon Log 2 Cinema Gamut to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CLog3_CGamut_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CLog3_CGamut_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Canon Log 3 Cinema Gamut to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.11Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.11Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:89a0a799-179a-4f50-bd2a-ccd2bbee14bd</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.11Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.11Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:08dd6a8f-85aa-4a9e-982e-0be7395dcb40</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Canon Log 3 Cinema Gamut to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CanonLog2_BT2020_D55__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CanonLog2_BT2020_D55__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Canon CanonLog2 BT2020 (Daylight) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.19Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.19Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:f092d3ad-0a29-4c51-94c0-dc91c0bf8f4b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.19Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.19Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:bed8d157-482e-4f59-a3b9-31d27e33650f</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Canon CanonLog2 BT2020 (Daylight)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_BT2020_D55.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CanonLog2_BT2020_Tng__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CanonLog2_BT2020_Tng__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Canon CanonLog2 BT2020 (Tungsten) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.19Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.19Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:66cb45d4-3847-42ce-8638-f15d1be80df7</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.19Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.19Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:52fca2bb-8a91-40c9-8a4f-f221c7a8582f</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Canon CanonLog2 BT2020 (Tungsten)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_BT2020_Tng.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CanonLog2_CinemaGamut_D55__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CanonLog2_CinemaGamut_D55__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Canon CanonLog2 CinemaGamut (Daylight) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.20Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.20Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:6e950a8e-1f8f-419f-9a85-6dab30d17014</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.20Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.20Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:bb1a331b-cdc6-4e8d-b76d-fd5cf0f3f0f4</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Canon CanonLog2 CinemaGamut (Daylight)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_CinemaGamut_D55.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CanonLog2_CinemaGamut_Tng__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CanonLog2_CinemaGamut_Tng__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Canon CanonLog2 CinemaGamut (Tungsten) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.20Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.20Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:f6872fa6-53a3-4781-b43c-afd0e7ecbdf5</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.20Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.20Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:3f164c80-6e76-494b-9666-4d70488bef5d</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Canon CanonLog2 CinemaGamut (Tungsten)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_CinemaGamut_Tng.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CanonLog3_BT2020_D55__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CanonLog3_BT2020_D55__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Canon CanonLog3 BT2020 (Daylight) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.20Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.20Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:95380727-74bf-4846-b0a7-f536ae6d4811</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.20Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.20Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f1fdcf8b-916f-4749-a5af-5443572d0444</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Canon CanonLog3 BT2020 (Daylight)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_BT2020_D55.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CanonLog3_BT2020_Tng__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CanonLog3_BT2020_Tng__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Canon CanonLog3 BT2020 (Tungsten) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.21Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.21Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:43e584d8-a55f-4180-9a94-df6dce88bf26</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.21Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.21Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:a8c09b56-51c1-4d67-8314-cf74b02775e9</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Canon CanonLog3 BT2020 (Tungsten)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_BT2020_Tng.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CanonLog3_CinemaGamut_D55__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CanonLog3_CinemaGamut_D55__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Canon CanonLog3 CinemaGamut (Daylight) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.21Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.21Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:7deb87c1-eafa-4884-a805-480672091edf</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.21Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.21Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:ef5f1c21-b39f-4bd4-a9fc-cb3943669c2a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Canon CanonLog3 CinemaGamut (Daylight)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_CinemaGamut_D55.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_CanonLog3_CinemaGamut_Tng__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_CanonLog3_CinemaGamut_Tng__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Canon CanonLog3 CinemaGamut (Tungsten) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.21Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.22Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:d71fe8db-8d53-4a3b-a9d4-2de01e91fc5b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.22Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.22Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:fd6dc18d-2462-4e74-8e8d-ad13933ad44c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Canon CanonLog3 CinemaGamut (Tungsten)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_CinemaGamut_Tng.a1.v2</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Log3G10_RWG_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Log3G10_RWG_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for RED Log3G10 REDWideGamutRGB to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.11Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.11Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:9aff64c7-32ea-4429-b86d-e0eba4a69fce</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.11Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.11Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:01960009-f9cd-4b75-96a1-c1647c27f6b1</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>RED Log3G10 REDWideGamutRGB to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_LogC_EI800_AWG_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_LogC_EI800_AWG_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ARRI LogC EI800 ALEXA Wide Gamut to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.11Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.11Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:50393efb-901f-444b-8182-6d1d181477d8</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.11Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.11Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:1cddc3be-6157-4cd2-bb30-a64be4394db5</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ARRI LogC EI800 ALEXA Wide Gamut to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC_EI800_AWG_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog1_SGamut_10i__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog1_SGamut_10i__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony SLog1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.22Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.22Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:d45a54e9-24ba-45e0-bab1-43424e8fc0db</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.22Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.22Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:40e61a3a-9052-409a-99fd-accfb5402ba9</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony SLog1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog1_SGamut_10i.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog1_SGamut_12i__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog1_SGamut_12i__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony SLog1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.22Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.22Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:aaeec8d8-88a7-414c-bed7-8b4f39083db6</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.22Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.22Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:67d3f993-3c3b-4a89-b275-b4964e365f43</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony SLog1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog1_SGamut_12i.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog2_SGamut_Daylight_10i__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog2_SGamut_Daylight_10i__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony SLog2 (daylight) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.22Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.23Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:9e1a41bd-c6e7-4c52-9c6c-dc617a4c389b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.23Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.23Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:15e8967a-c60d-485c-8e8e-02924dac7145</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony SLog2 (daylight)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Daylight_10i.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog2_SGamut_Daylight_12i__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog2_SGamut_Daylight_12i__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony SLog2 (daylight) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.23Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.23Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:b84cf87c-ccde-436b-aa85-683f27a245d7</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.23Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.23Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:1ee32579-8ac3-4203-9d83-4cc35a7df07f</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony SLog2 (daylight)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Daylight_12i.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog2_SGamut_Tungsten_10i__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog2_SGamut_Tungsten_10i__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony SLog2 (tungsten) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.23Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.23Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:62804b7d-7444-4049-b3f3-07d2b51cd9a2</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.23Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.23Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:9388023f-1102-415c-8f28-8b85314f9df7</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony SLog2 (tungsten)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Tungsten_10i.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog2_SGamut_Tungsten_12i__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog2_SGamut_Tungsten_12i__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony SLog2 (tungsten) with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.23Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.24Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:83cbba39-b1f7-4817-9774-3152ebc2e941</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.24Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.24Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:81a98234-7ecc-4fec-84c7-bd67ae9ca4a9</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony SLog2 (tungsten)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog2_SGamut_Tungsten_12i.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog3_SGamut3Cine__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog3_SGamut3Cine__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony SLog3 SGamut3Cine with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.24Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.24Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:9dde449e-c675-4d35-b973-a3432950f2f6</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.24Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.24Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:657f02df-ffc4-4963-a29a-e79c3d74e935</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony SLog3 SGamut3Cine</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3Cine.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog3_SGamut3Cine_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog3_SGamut3Cine_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log3 S-Gamut3.Cine to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.12Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.12Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ac5b2b4d-ab8a-4e8a-825a-dff7ffcb40a0</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.12Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.12Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f14f5885-b345-4344-9308-f2255dde7eed</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log3 S-Gamut3.Cine to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog3_SGamut3__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog3_SGamut3__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony SLog3 SGamut3 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.24Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.24Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:1ac84c3c-2609-4616-99fd-e7020297e40b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.24Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.24Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:4e8676f6-73f2-4c0d-861b-9487689d4218</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony SLog3 SGamut3</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog3_SGamut3_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog3_SGamut3_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log3 S-Gamut3 to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.12Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.12Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:d27e3707-3442-42a6-b1b3-a4bb259bc720</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.12Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.12Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:de27ecb0-d124-466c-ba26-670168de07c4</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log3 S-Gamut3 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog3_Venice_SGamut3Cine_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog3_Venice_SGamut3Cine_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log3 VENICE S-Gamut3.Cine to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.13Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.13Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:82ec4e60-a021-4319-adce-952d5464346b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.13Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.13Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:6156b465-4c9b-48b7-8855-0970de865796</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log3 VENICE S-Gamut3.Cine to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_SLog3_Venice_SGamut3_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_SLog3_Venice_SGamut3_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log3 VENICE S-Gamut3 to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.12Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.12Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:f2a9a5ae-ab29-422d-aea0-32a2af5273bd</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.12Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.12Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f04c688f-6ed5-451a-8e1c-e1f7de00b3a5</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log3 VENICE S-Gamut3 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_VLog_VGamut_to_ACES__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_VLog_VGamut_to_ACES__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Panasonic Varicam V-Log V-Gamut to ACES2065-1 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.13Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.13Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:150cac9b-e0a8-4a84-a144-a0b65c0ea3fb</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.13Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.13Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f7de2cc3-fb58-4925-8680-003928f24016</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Panasonic Varicam V-Log V-Gamut to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.VLog_VGamut_to_ACES.a1.1.0</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Venice_SLog3_SGamut3Cine__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Venice_SLog3_SGamut3Cine__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3.Cine with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.25Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.25Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:cbc8d424-002d-44b5-a0c8-68db8dd81675</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.25Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.25Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:3ea586af-8317-41b8-aea4-3b530b8f862a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3.Cine</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3Cine.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces1/idt_Venice_SLog3_SGamut3__odt_Rec709_100nits_dim.amf
+++ b/examples/generated/aces1/idt_Venice_SLog3_SGamut3__odt_Rec709_100nits_dim.amf
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3 with ACES 1.0 Output - Rec.709</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:32:53.25Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:32:53.25Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:7ec41b75-efa0-4327-ad30-a29d79f413a2</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:32:53.25Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:32:53.25Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:38e3e884-6e37-4280-867b-a7084bf08ea8</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACES 1.0 Input - Sony Venice S-Log3 S-Gamut3</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>ACES 1.0 Output - Rec.709</aces:description>
+            <aces:referenceRenderingTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScc_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_ACEScc_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScc to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.55Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.55Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:4edc7b33-d16d-47a3-98bf-e257f39e8894</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.55Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.55Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:2c48ee30-6e38-4a64-8b9c-60990d0befdc</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScc to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScc_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_1000nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_1000nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 1000 nit (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.64Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.64Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:84ed0f0f-c0f4-4517-9c0c-d6953db2192c</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.64Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.64Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:94dcb500-fce0-4ca6-8d66-02a858eddea4</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 1000 nit (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_1000nit_in_P3_D65_sRGB_Piecewise.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_1000nit_in_P3_D65_sRGB_Piecewise.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Extended DisplayP3 (1000 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.64Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.64Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:4e8ca333-024f-4ad2-bd20-c6ba7149719b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.64Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.64Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:1fe5e087-da8f-446c-947a-fb5ac78e1e50</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Extended DisplayP3 (1000 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_1000nit_in_Rec2100_D65_HLG.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_1000nit_in_Rec2100_D65_HLG.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 HLG (1000 nit P3-D60 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.65Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.65Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:0e157f9b-aa36-4f52-b089-742fe566a934</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.65Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.65Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:1d177f59-4fcd-459c-a0af-a8a315aadb99</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 HLG (1000 nit P3-D60 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_Rec2100-D65_HLG.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_1000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_1000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (1000 nit P3-D60 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.65Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.65Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:3c7dc889-fb46-4faf-b65e-04316c7bcabd</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.65Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.65Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:cf94481d-3912-42cc-90b7-88d8610676be</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (1000 nit P3-D60 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_100nit_in_P3_D65_Gamma2pt2.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_100nit_in_P3_D65_Gamma2pt2.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DisplayP3 Gamma 2.2 (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.65Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.65Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:bf681a8a-f3e5-49b6-9be6-688d98b53c6c</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.65Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.65Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:71ef408c-e6d1-4fb7-b3a1-69a989ec6746</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DisplayP3 Gamma 2.2 (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_100nit_in_P3-D65_Gamma2pt2.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_100nit_in_P3_D65_sRGB_Piecewise.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_100nit_in_P3_D65_sRGB_Piecewise.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DisplayP3 (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.65Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.65Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:5e08d338-8257-491f-b717-343e0c7427c3</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.65Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.65Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:094e3ee6-c648-442f-98e8-431169338318</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DisplayP3 (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_108nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_108nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (108 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.66Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.66Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:5d988034-3083-46e5-8ba3-6a1391edf998</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.66Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.66Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:9d6c82b4-4f9d-4bc0-9930-6cfc36180946</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (108 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_108nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_2000nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_2000nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (2000 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.66Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.66Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:3d48f7b5-4214-40fc-8201-a2ba100a076e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.66Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.66Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:7240d4e5-1e03-42f6-8836-3ea8da8ec15c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (2000 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_2000nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_2000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_2000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (2000 nit P3-D60 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.66Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.66Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:4ef47309-034b-4ec3-88d5-dfcc5f52bb14</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.66Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.66Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:4b11c7b3-8f8e-461f-91bd-0b37b6441539</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (2000 nit P3-D60 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_300nit_in_XYZ_E_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_300nit_in_XYZ_E_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DCDM (300 nit P3-D60 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.67Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.67Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:024355c6-f2bc-439c-baea-f85bd87c0f04</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.67Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.67Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:62783d74-ae12-4671-954d-8563c8d28b0a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DCDM (300 nit P3-D60 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_300nit_in_XYZ-E_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_4000nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_4000nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (4000 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.67Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.67Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:092aa9c5-930b-4b7f-a7f8-ec8db680d0f1</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.67Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.67Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:2b485ab2-ce55-48e3-8eda-135ee6cd432b</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (4000 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_4000nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_4000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_4000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (4000 nit P3-D60 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.67Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.67Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:35c3625a-ef02-4832-affb-40ce40420b1d</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.67Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.67Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:a33cac7c-b90b-4850-b17a-3ff20ac33cc5</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (4000 nit P3-D60 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_48nit_in_P3_D65_Gamma2pt6.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_48nit_in_P3_D65_Gamma2pt6.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.68Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.68Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:70f38d47-dc6e-438f-8f20-00665821c1a1</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.68Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.68Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:8fd961da-86fd-4aea-8886-0a240bf27d03</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_48nit_in_XYZ_E_Gamma2pt6.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_48nit_in_XYZ_E_Gamma2pt6.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DCDM (P3-D60 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.68Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.68Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:45478c3f-904a-4756-82a4-480c66fbf037</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.68Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.68Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:b1422271-ff19-4391-ad24-d9a532509ea4</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DCDM (P3-D60 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_48nit_in_XYZ-E_Gamma2pt6.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_500nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_500nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (500 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.68Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.68Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:1905cb55-d11a-4dbe-bb31-298cf90cd881</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.68Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.68Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:61f408f3-1206-4b65-a305-bade44af52e9</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (500 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_500nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_500nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D60_500nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (500 nit P3-D60 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.69Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.69Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:d4341849-98cc-4873-a730-1ae8522aaea9</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.69Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.69Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:87bccd99-6733-4771-a361-2e2617b90235</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (500 nit P3-D60 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D60_500nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_1000nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_1000nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 1000 nit</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.69Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.69Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:3e9dc2ee-7ddf-4b0d-bd24-e26434eaa7db</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.69Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.69Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:cf547aa3-afc1-4217-95fb-9ebc32059bf0</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 1000 nit</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_1000nit_in_P3_D65_sRGB_Piecewise.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_1000nit_in_P3_D65_sRGB_Piecewise.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Extended DisplayP3 (1000 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.69Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.69Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:25f0b91e-28ef-4804-8312-255125ae79f9</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.69Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.69Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:3ac69c59-fcc9-419e-b622-d918db0a3fcc</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Extended DisplayP3 (1000 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_P3-D65_sRGB-Piecewise.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_1000nit_in_Rec2100_D65_HLG.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_1000nit_in_Rec2100_D65_HLG.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 HLG (1000 nit P3-D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.70Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.70Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:38c5a98b-ee9f-490a-b77f-34f0ed7e7ec6</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.70Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.70Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:8fbc74c6-4d75-4a93-8376-400ad3cf58eb</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 HLG (1000 nit P3-D65 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_Rec2100-D65_HLG.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_1000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_1000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (1000 nit P3-D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.70Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.70Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:35761757-dbb4-4483-9376-e4a62d647ae1</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.70Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.70Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:f08e1fac-5f40-4812-a78d-7417d0dd088a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (1000 nit P3-D65 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_100nit_in_P3_D65_Gamma2pt2.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_100nit_in_P3_D65_Gamma2pt2.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DisplayP3 Gamma 2.2</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.70Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.70Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:bf3f67ad-abfd-4ace-a2e3-0bef43317d89</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.70Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.70Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:cc922b4c-d7ec-4296-b6c1-a3a1fe5d2540</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DisplayP3 Gamma 2.2</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_100nit_in_P3-D65_Gamma2pt2.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_100nit_in_P3_D65_sRGB_Piecewise.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_100nit_in_P3_D65_sRGB_Piecewise.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DisplayP3</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.71Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.71Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:00e8989a-5921-476c-a3d9-e5cc93ce6175</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.71Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.71Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:e53936aa-431a-468a-96de-7d1c37ac8cf0</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DisplayP3</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_108nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_108nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (108 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.71Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.71Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:e13e51a0-be17-4fc1-b645-1f936fa0d5ea</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.71Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.71Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:5b795fcd-28f1-4107-814f-34df0d352634</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (108 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_108nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_2000nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_2000nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (2000 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.71Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.71Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:43e5f92d-16e9-4130-a9e2-81a8904a7869</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.71Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.71Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:e9c10442-63d5-43ac-9000-c3e726578dc8</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (2000 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_2000nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_2000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_2000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (2000 nit P3-D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.71Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.72Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ab91be78-8ea5-4a3c-8d94-1d3317914662</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.72Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.72Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:657e2c78-7f1b-4d0e-b5a9-314f749e844c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (2000 nit P3-D65 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_300nit_in_XYZ_E_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_300nit_in_XYZ_E_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DCDM (300 nit P3-D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.72Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.72Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:17f71d29-b120-4e72-82f8-8f3f53916e46</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.72Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.72Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:474bbdda-cbff-46af-a0e9-ae03ab8a413d</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DCDM (300 nit P3-D65 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_300nit_in_XYZ-E_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_4000nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_4000nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (4000 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.72Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.72Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:9935c50f-e68e-4bf3-a750-99ee0d4b2668</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.72Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.72Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:db4a9e52-5b16-4994-832a-96c19f9692f4</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (4000 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_4000nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_4000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_4000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (4000 nit P3-D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.72Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.72Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ea2a4a61-9fa9-432e-99df-73e187d282d0</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.72Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.72Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:52367f72-ec87-4294-b655-5dd55fa05081</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (4000 nit P3-D65 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_48nit_in_P3_D65_Gamma2pt6.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_48nit_in_P3_D65_Gamma2pt6.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.73Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.73Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:350b8d34-036d-491f-97f3-e5b89bdd0dd7</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.73Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.73Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:81825c1c-2447-4f8a-b0e3-4f21fbe3a513</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_48nit_in_XYZ_E_Gamma2pt6.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_48nit_in_XYZ_E_Gamma2pt6.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DCDM (P3-D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.73Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.73Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:55502919-9605-4009-9e28-a58a00e6509e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.73Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.73Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:c77416e7-1884-4d4d-a99d-c2de9a6bea33</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DCDM (P3-D65 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_48nit_in_XYZ-E_Gamma2pt6.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_500nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_500nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (500 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.73Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.73Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:2522587e-545e-4975-af04-d73489087f87</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.73Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.73Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:9ae0c517-4e03-4956-b7d4-aade6a934e16</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (500 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_500nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_500nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_P3_D65_500nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (500 nit P3-D65 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.74Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.74Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:60c4bf27-9d73-470e-b413-db2717869dc5</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.74Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.74Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:18f69f54-1abf-43cf-8be1-cb29a0c213a0</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (500 nit P3-D65 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.P3-D65_500nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D60_1000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D60_1000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (1000 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.74Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.74Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:93f20523-333f-4575-bd8e-4f3d983a065e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.74Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.74Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:e79fec3a-da37-40ae-93fd-d9576bdf1266</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (1000 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_1000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D60_2000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D60_2000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (2000 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.74Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.74Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:74e62943-97fd-4379-b27b-952f31eb59d7</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.74Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.74Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:addce8e6-d211-41df-85a1-e57ea88560f3</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (2000 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_2000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D60_4000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D60_4000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (4000 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.75Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.75Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:109323a8-cafd-49c9-9cb2-0299203bcbc0</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.75Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.75Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:9e7ab74d-3ef8-497d-b20c-4e5c7c0499a2</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (4000 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_4000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D60_500nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D60_500nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (500 nit) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.75Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.75Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:0047c5f7-0043-4c96-a740-90c1de6ac29d</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.75Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.75Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:db58efd6-4082-43d1-9db0-1d80d723358c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (500 nit) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D60_500nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D65_1000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D65_1000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (1000 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.75Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.75Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:178b0c2f-3c73-4864-a98a-f1d3e3294c6a</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.75Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.75Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:90053ea0-7602-4a33-b332-e709429d62dd</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (1000 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_1000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D65_2000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D65_2000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (2000 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.76Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.76Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:a976e25c-3873-4d01-955c-45f12afa4b26</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.76Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.76Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:5a6ca1d7-f145-40bf-aeb8-1cf122cd2b52</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (2000 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_2000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D65_4000nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D65_4000nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (4000 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.76Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.76Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ef86675b-3faf-47be-ab97-aa35a7645ca0</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.76Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.76Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:c0953afb-6b00-442b-b05f-6a7010a201e1</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (4000 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_4000nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D65_500nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec2100_D65_500nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (500 nit)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.76Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.76Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:1505414c-1129-453c-bde3-039766ab12e7</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.76Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.76Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:dc04c9db-4bb9-4854-967e-d2c38f1ecbdc</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (500 nit)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec2100-D65_500nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (100 nit Rec.709 Limited) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.77Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.77Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:69311daf-965a-4741-86d2-693eb33f3e53</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.77Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.77Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:c4343a36-3945-4ec0-8516-4b1adbaa550d</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (100 nit Rec.709 Limited) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_P3_D65_sRGB_Piecewise.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_P3_D65_sRGB_Piecewise.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DisplayP3 (100 nit Rec.709 Limited) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.77Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.77Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:6e0f8b93-411d-4077-9176-a7e224ef4bdc</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.77Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.77Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:5a9d14d1-b344-4a2a-8557-e147d05d4ea7</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DisplayP3 (100 nit Rec.709 Limited) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_P3-D65_sRGB-Piecewise.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (100 nit Rec.709 Limited) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.77Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.77Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:7a123fec-7dde-4ca7-8a33-3a86a1c54473</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.77Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.77Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:a35f708c-6a2d-41b9-b928-531fea13c1bf</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (100 nit Rec.709 Limited) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.709 BT.1886 (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.78Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.78Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:7cacc8ef-f058-4e92-8532-b3871f78bfb1</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.78Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.78Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:6293db56-453b-4e27-81d7-03115f132c78</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886 (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_Rec709_D65_Gamma2pt2.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_Rec709_D65_Gamma2pt2.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with sRGB Gamma 2.2 (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.78Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.78Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:78aead72-7a6a-41fb-86f8-20b2a1c4649e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.78Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.78Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:896b7390-b1df-42e4-9f08-be5007974fc9</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>sRGB Gamma 2.2 (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_Gamma2pt2.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_Rec709_D65_sRGB_Piecewise.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_100nit_in_Rec709_D65_sRGB_Piecewise.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with sRGB Piecewise (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.78Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.78Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:5eb9da22-7ce2-4690-9fb7-36d299500042</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.78Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.78Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:70a813ab-242e-4e04-a473-399379a2cc0c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>sRGB Piecewise (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_48nit_in_P3_D65_Gamma2pt6.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D60_48nit_in_P3_D65_Gamma2pt6.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 (Rec.709 Limited) (D60 simulation)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.79Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.79Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:7f114c19-7ac0-4f94-b6ef-b8ccb15f4b50</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.79Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.79Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:97a0a76f-10dc-4da5-906e-b52e8bc33c0f</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 (Rec.709 Limited) (D60 simulation)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D60_48nit_in_P3-D65_Gamma2pt6.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_P3_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_P3_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 ST2084 (100 nit Rec.709 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.79Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.79Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:91c6f562-bd95-435d-a06d-59754c803650</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.79Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.79Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:b874d4f6-d641-4c55-9b45-b3353638bda8</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 ST2084 (100 nit Rec.709 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_P3-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_P3_D65_sRGB_Piecewise.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_P3_D65_sRGB_Piecewise.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with DisplayP3 (100 nit Rec.709 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.79Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.79Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:9ce89c75-9d4c-4803-85a5-e4b913473179</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.79Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.79Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:fff47f85-69ca-40b3-9a7f-0b45c146bc9c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>DisplayP3 (100 nit Rec.709 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_P3-D65_sRGB-Piecewise.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_Rec2100_D65_ST2084.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_Rec2100_D65_ST2084.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.2100 ST2084 (100 nit Rec.709 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.79Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.80Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:72cb993d-25a1-4009-8e61-eb4e87df7811</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.80Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.80Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:592e8285-28be-46d7-a280-0f5e2672f8b3</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.2100 ST2084 (100 nit Rec.709 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec2100-D65_ST2084.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.80Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.80Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:b19594c4-5c9e-4c21-912c-ff1efcf4cca6</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.80Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.80Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:54cef5ef-6e28-4531-8cb8-438492fbcc69</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_Gamma2pt2.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_Gamma2pt2.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with sRGB Gamma 2.2</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.80Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.80Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ef0be1da-bfcb-4e99-ac5a-b8166b43dfce</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.80Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.80Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:b06dd669-565d-4dd9-b35b-6c0e0415f138</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>sRGB Gamma 2.2</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_Gamma2pt2.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_sRGB_Piecewise.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_sRGB_Piecewise.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with sRGB Piecewise</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.81Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.81Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:72bf40d7-a4a5-41c7-9d8b-d9d43de5fbd2</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.81Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.81Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:02b820d7-ef9b-4c55-a648-1f2c041d456f</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>sRGB Piecewise</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_sRGB-Piecewise.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_48nit_in_P3_D65_Gamma2pt6.amf
+++ b/examples/generated/aces2/idt_ACEScct_to_ACES__odt_Rec709_D65_48nit_in_P3_D65_Gamma2pt6.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScct to ACES2065-1 with P3-D65 (Rec.709 Limited)</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.81Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.81Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:e6b75716-194b-44fc-9a23-93fe67fa79ec</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.81Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.81Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:e2b0b84c-935b-4f85-9084-a019fd910120</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScct to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScct_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>P3-D65 (Rec.709 Limited)</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_48nit_in_P3-D65_Gamma2pt6.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACEScg_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_ACEScg_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACEScg to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.56Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.56Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:3dbb3f5a-a877-4f94-8812-9e4203b0e33b</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.56Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.56Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:d41d041b-b812-41a0-b75b-646c6fa36af3</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACEScg to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACEScg_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACESproxy10i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_ACESproxy10i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACESproxy to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.56Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.56Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:0a6c08b7-136a-4b1d-b628-505a1fd83560</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.56Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.56Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:5f1ea4e8-fab0-4ccf-af51-2afb0f5c7be3</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACESproxy to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACESproxy10i_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ACESproxy12i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_ACESproxy12i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ACESproxy to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.56Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.56Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:183c317d-e618-422b-bad9-497da9a4a99d</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.56Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.56Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:b85f22f9-b324-4adb-a114-cdf05feca9f8</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ACESproxy to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ACESproxy12i_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ADX10_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_ADX10_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ADX10 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.57Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.57Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:e8511aec-e8a9-481b-95e0-9b695cb2ae40</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.57Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.57Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:c6f1cc0c-6adf-4ab3-8a33-95aa38429509</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ADX10 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ADX10_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_ADX16_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_ADX16_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ADX16 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.57Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.57Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:a555ba85-bea5-4f25-a60b-aa2eaa1b28ba</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.57Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.57Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:da66eadb-af33-4ef9-bb7d-4655d7ca1bdd</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ADX16 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Academy.ADX16_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_AppleLog_BT2020_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_AppleLog_BT2020_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for AppleLog Rec2020 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.57Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.57Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:45213818-f87e-457e-8741-89cf8fdd7e2e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.57Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.57Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:19aacdf7-b9eb-44b6-9171-1c0c0cee9e6b</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>AppleLog Rec2020 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Apple.AppleLog_BT2020_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_BMDFilm_WideGamut_Gen5_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_BMDFilm_WideGamut_Gen5_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Blackmagic Film Wide Gamut (Gen 5) to ACES2605-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.58Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.58Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:661ff682-d44e-4890-ba96-85ff7c30fae6</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.58Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.58Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:2e8ab09a-8e1e-45fd-b8c2-118311ff3171</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Blackmagic Film Wide Gamut (Gen 5) to ACES2605-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Blackmagic.BMDFilm_WideGamut_Gen5_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_CLog2_BT2020_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_CLog2_BT2020_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Canon Log 2 BT.2020 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.59Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.59Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:4fd74a3a-a729-4c6c-81a7-363d91d5fb1e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.59Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.59Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:a192682a-2799-4912-b126-94f43c8cba2b</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Canon Log 2 BT.2020 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog2_BT2020_to_ACES.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_CLog2_CGamut_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_CLog2_CGamut_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Canon Log 2 Cinema Gamut to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.59Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.59Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:2c83a9c6-2228-4ec8-ba26-4853b75662ec</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.59Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.59Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:4b9ff612-7eed-49e1-818f-470baa90761a</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Canon Log 2 Cinema Gamut to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog2_CGamut_to_ACES.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_CLog3_BT2020_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_CLog3_BT2020_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Canon Log 3 BT.2020 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.59Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.59Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:b2914479-87cb-4fe1-9db5-28efbacca3bf</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.59Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.59Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:4ab2e6a5-538f-4519-b164-1b867db776ee</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Canon Log 3 BT.2020 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog3_BT2020_to_ACES.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_CLog3_CGamut_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_CLog3_CGamut_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Canon Log 3 Cinema Gamut to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.59Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.59Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:231fd2fd-9cad-4497-aeaf-2650a9d6d0ed</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.59Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.59Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:3f0e36cc-9026-4376-bb0f-d895e2f430ac</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Canon Log 3 Cinema Gamut to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Canon.CLog3_CGamut_to_ACES.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_DLog_DGamut_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_DLog_DGamut_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for DJI DLog DGamut to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.60Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.60Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:631501e5-0f33-48fd-8d7a-00d722fde2f3</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.60Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.60Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:be273a94-9ad3-48ee-bc74-79fd841dd61c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>DJI DLog DGamut to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.DJI.DLog_DGamut_to_ACES.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_Log3G10_RWG_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_Log3G10_RWG_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for RED Log3G10 REDWideGamutRGB to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.60Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.60Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:92ab7db5-11ee-4ad9-a0f1-57f4767d22c3</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.60Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.60Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:b81f5e1a-827d-4e38-ace0-31af78f0ce64</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>RED Log3G10 REDWideGamutRGB to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Red.Log3G10_RWG_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_LogC3_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_LogC3_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ARRI LogC3 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.58Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.58Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ec1a24a4-553d-4c56-84cb-b855c7fbee29</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.58Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.58Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:50e3a2d9-1679-4b9e-b6e4-d730fb4224eb</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ARRI LogC3 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_LogC4_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_LogC4_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for ARRI LogC4 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.58Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.58Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:ac52034b-5a2c-4294-9e5a-5f3e65c93470</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.58Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.58Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:7ae2846f-adfb-4ed8-9c46-a5adabee920c</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>ARRI LogC4 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC4_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_SLog1_SGamut_10i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_SLog1_SGamut_10i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log1 S-Gamut 10 bits to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.61Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.61Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:5deca16a-d15a-4d42-82e7-3468ef3b1dd9</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.61Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.61Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:25a73bc0-dffe-4833-b597-611fed64f08f</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log1 S-Gamut 10 bits to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog1_SGamut_10i_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_SLog1_SGamut_12i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_SLog1_SGamut_12i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log1 S-Gamut 12 bits to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.61Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.61Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:cefd0706-386a-4bc8-9b45-d36109b8f2a9</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.61Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.61Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:87b1da76-f58f-41e0-b37d-e3b0d2a36e14</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log1 S-Gamut 12 bits to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog1_SGamut_12i_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_SLog2_SGamut_Daylight_10i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_SLog2_SGamut_Daylight_10i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log2 S-Gamut2 (Daylight) 10 bits to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.61Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.61Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:7ea29f51-1205-4845-82f3-6039a48f043d</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.61Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.61Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:dd085b14-cd1e-4a8d-96d3-f525bb3f3c1d</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log2 S-Gamut2 (Daylight) 10 bits to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog2_SGamut_Daylight_10i_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_SLog2_SGamut_Daylight_12i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_SLog2_SGamut_Daylight_12i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log2 S-Gamut (Daylight) 12 bits to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.62Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.62Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:9bb57cb9-cc41-45e6-87af-72698c228882</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.62Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.62Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:6e5f152b-7dc0-44c3-8fb0-32e1fff4ee62</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log2 S-Gamut (Daylight) 12 bits to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog2_SGamut_Daylight_12i_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_SLog2_SGamut_Tungsten_10i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_SLog2_SGamut_Tungsten_10i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log2 S-Gamut (tungsten) 10 bits to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.62Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.62Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:6b10172c-2c49-4b53-9bc2-8933273e851e</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.62Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.62Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:cb386073-0207-4822-840a-bb0ac14f52c3</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log2 S-Gamut (tungsten) 10 bits to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog2_SGamut_Tungsten_10i_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_SLog2_SGamut_Tungsten_12i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_SLog2_SGamut_Tungsten_12i_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log2 S-Gamut (tungsten) 12 bits to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.62Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.62Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:199dc289-1ace-4af4-91d1-d708c69d8198</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.62Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.62Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:8658a536-0b1b-4441-9add-72dfe8e38c72</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log2 S-Gamut (tungsten) 12 bits to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog2_SGamut_Tungsten_12i_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_SLog3_SGamut3Cine_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_SLog3_SGamut3Cine_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log3 S-Gamut3Cine to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.63Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.63Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:8c8aa124-b872-4bbb-94f5-f3e280023da7</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.63Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.63Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:c6646699-3ed9-4120-a5c3-b9b2803a790f</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log3 S-Gamut3Cine to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog3_SGamut3Cine_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_SLog3_SGamut3_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_SLog3_SGamut3_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony S-Log3 S-Gamut3 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.63Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.63Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:52cbf59d-1c36-4fdb-8481-ae6e59b10168</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.63Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.63Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:2e8a6e66-d3ac-4bf3-9b71-846915ec8894</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony S-Log3 S-Gamut3 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.SLog3_SGamut3_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_VLog_VGamut_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_VLog_VGamut_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Panasonic Varicam V-Log V-Gamut to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.60Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.60Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:95caeb5c-8bd9-495b-9a09-5d2da3bed145</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.60Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.60Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:19ded572-2f7b-438f-9ec4-62d1c9da8325</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Panasonic Varicam V-Log V-Gamut to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Panasonic.VLog_VGamut_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_Venice_SLog3_SGamut3Cine_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_Venice_SLog3_SGamut3Cine_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony VENICE S-Log3 S-Gamut3Cine to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.64Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.64Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:96bc3660-5d3d-42a1-bd83-8a145d1861e5</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.64Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.64Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:88878596-47a7-4431-9145-b2923319d0b2</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony VENICE S-Log3 S-Gamut3Cine to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.Venice_SLog3_SGamut3Cine_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/examples/generated/aces2/idt_Venice_SLog3_SGamut3_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
+++ b/examples/generated/aces2/idt_Venice_SLog3_SGamut3_to_ACES__odt_Rec709_D65_100nit_in_Rec709_D65_BT1886.amf
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile xmlns:aces="urn:ampas:aces:amf:v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cdl="urn:ASC:CDL:v1.01" version="2.0">
+    <aces:amfInfo>
+        <aces:description>AMF for Sony VENICE S-Log3 S-Gamut3 to ACES2065-1 with Rec.709 BT.1886</aces:description>
+        <aces:author>
+            <aces:name>AMF Generator Script</aces:name>
+            <aces:emailAddress>amf.generator@example.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2025-07-21T19:31:48.63Z</aces:creationDateTime>
+            <aces:modificationDateTime>2025-07-21T19:31:48.63Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:01028064-5445-4ab4-817e-16b4e413512c</aces:uuid>
+    </aces:amfInfo>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:dateTime>
+                <aces:creationDateTime>2025-07-21T19:31:48.63Z</aces:creationDateTime>
+                <aces:modificationDateTime>2025-07-21T19:31:48.63Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:9d57fe3d-f12d-4f42-965b-2504722568d2</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>2</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="false">
+            <aces:description>Sony VENICE S-Log3 S-Gamut3 to ACES2065-1</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:CSC.Sony.Venice_SLog3_SGamut3_to_ACES.a2.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:outputTransform applied="false">
+            <aces:description>Rec.709 BT.1886</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v2.0:Output.Academy.Rec709-D65_100nit_in_Rec709-D65_BT1886.a2.v1</aces:transformId>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>


### PR DESCRIPTION
Over the past year, AMF implementers have requested new sample AMFs to cover the range of possible pipelines for both ACES 1.3 and the new ACES 2.0 transforms.  

These new sample AMFs were programmatically generated and validated against the XML schema, using offical ACES transform IDs / URNs from the recently published [JSON registry](https://github.com/ampas/aces/blob/101f126a2f39fd951db4e7ed711afaec74dfb435/transforms.json).

They cover the following combinations:
1. Single IDT* and all possible ODTs
2. Single ODT* with all possible IDTs

_*The IDT chosen was the `CSC` for `ACEScct` to avoid choosing a third-party manufacturer._
_*The ODT chosen was `Rec.709 BT.1886`._

For ACES 1.3, this resulted in 76 AMFs, and for ACES 2.0, this resulted in 81 AMFs, for a total of 157 AMFs.

This PR will likely be followed up with more edge cases (e.g. custom IDTs and LMTs, using inverse ODTs as the input, etc) depending on the needs of implementers.  There may also be value in creating an "invalid" example AMF set in order to help catch common mistakes or errors.