### PR TITLE
Updated git workflow to validate AMFs recursively

### DIFF
--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -21,6 +21,7 @@ jobs:
 
     - name: Validate XML Files
       run: |
-        for file in examples/*.amf; do
-          xmllint --noout --schema schema/acesMetadataFile.xsd $file
+        shopt -s globstar
+        for file in examples/**/*.amf; do
+          xmllint --noout --schema schema/acesMetadataFile.xsd "$file"
         done


### PR DESCRIPTION
Previously, the git workflow validated only example AMFs in the top-level directory (`examples/*.amf`).

This change searches for AMFs recursively within the `examples` folder so that any future AMFs we add in subdirectories will be validated.
